### PR TITLE
Embed the formatted starter kit scripts in the website

### DIFF
--- a/docs/content/azure-tutorial.fsx
+++ b/docs/content/azure-tutorial.fsx
@@ -20,7 +20,7 @@ The easiest path to provision an MBrace cluster on Azure using
 an Azure Cloud Service is to use [Brisk Engine](http://briskengine.com).
 See [Getting Started with MBrace using Brisk Engine](https://github.com/mbraceproject/MBrace.StarterKit/blob/master/azure/brisk-tutorial.md#get-started-with-brisk).
 
-## Provisioning Your Cluster an Azure Cloud Service Explicitly
+## Provisioning Your Cluster using an Explicit Azure Cloud Service 
 
 In some cases you may decide to provision explicitly, if the options provided
 by Brisk Engine do not yet meet your needs.  

--- a/docs/tools/generate.fsx
+++ b/docs/tools/generate.fsx
@@ -14,7 +14,7 @@ let githubLink = "http://github.com/mbraceproject/MBrace.Core"
 
 // Specify more information about your project
 let info =
-  [ "project-name", "MBrace"
+  [ "project-name", "MBrace.Core and MBrace.Azure"
     "project-author", "Jan Dzik, Nick Palladinos, Kostas Rontogiannis, Eirik Tsarpalis"
     "project-summary", "An open source framework for large-scale distributed computation and data processing written in F#."
     "project-github", githubLink


### PR DESCRIPTION
This embeds ALL the scripts from MBrace.StarterKit in a uniform way under the m-brace.net website.

For example: http://www.m-brace.net/azure/HandsOnTutorial/1-hello-world.html

We don't yet link to any of the scripts so this is not yet "live" for the world to see in any real sense.  The formatting is not ideal and we have to fix the scripts up with "hide" and (*\* ... *) markers if we want them to look good.
