### PR TITLE
update doc generation

### DIFF
--- a/docs/files/index.html
+++ b/docs/files/index.html
@@ -140,10 +140,13 @@
                                     <ul class="dropdown-menu">
                                         <li><a href="programming-model.html">Programming Model</a></li>
                                         <li class="divider"></li>
-                                        <li><a href="thespian-tutorial.html">Getting Started (Local)</a></li>
+                                        <li><a href="thespian-tutorial.html">Getting Started (Locally Simulated)</a></li>
                                         <li><a href="azure-tutorial.html">Getting Started (Azure)</a></li>
                                        <li class="divider"></li>
-                                        <li><a href="reference/index.html">API Reference</a></li>
+                                        <li><a href="reference/core/index.html">API Reference (MBrace.Core)</a></li>
+                                        <li><a href="reference/runtime/index.html">API Reference (MBrace.Runtime)</a></li>
+                                        <li><a href="reference/flow/index.html">API Reference (MBrace.Flow)</a></li>
+                                        <li><a href="reference/azure/index.html">API Reference (MBrace.Azure)</a></li>
                                     </ul>
                                 </li>
                                 <li class="dropdown">
@@ -192,7 +195,7 @@
 
                     <div class="col-md-9">
                         <!-- title + shortdesc -->
-                        <h3>Integrated Data Scripting for the Cloud - Get started with MBrace.Core (local) or MBrace.Azure (Azure) today.</h3>
+                        <h3>Integrated Data Scripting for the Cloud - Get started with MBrace today.</h3>
                     </div>
 
 

--- a/docs/tools/templates/template.cshtml
+++ b/docs/tools/templates/template.cshtml
@@ -52,15 +52,19 @@
             <li><a href="@Properties["project-github"]/blob/master/RELEASE_NOTES.md">Release Notes</a></li>
 
             <li class="nav-header">Getting Started</li>
-            <li><a href="@Root/azure-tutorial.html">Azure tutorial</a></li>
+            <li><a href="@Root/thespian-tutorial.html">Local cluster</a></li>
+            <li><a href="@Root/azure-tutorial.html">Azure cluster</a></li>
             <li class="divider"></li>
-            <li><a target="_blank" href="http://skillsmatter.com/skillscasts/5157-mbrace-large-scale-distributed-computation-with-f">Video presentation</a></li>
             <li><a target="_blank" href="@Root/mbrace-plos.pdf">PLOS'13 Publication</a></li>
 
             <li class="nav-header">Documentation</li>
             <li><a href="@Root/programming-model.html">Programming model</a></li>
-            <!--<li><a target="_blank" href="@Root/mbrace-manual.pdf">MBrace Manual</a></li>-->
-            <li><a href="@Root/reference/index.html">API Reference</a></li>
+            <li><a href="@Root/reference/core/index.html">API Reference (MBrace.Core)</a></li>
+            <li><a href="@Root/reference/runtime/index.html">API Reference (MBrace.Runtime)</a></li>
+            <li><a href="@Root/reference/flow/index.html">API Reference (MBrace.Flow)</a></li>
+            <li class="divider"></li>
+            <li><a href="@Root/reference/azure/index.html">Reference (Azure)</a></li>
+            <li><a href="@Root/reference/thespian/index.html">Reference (Local)</a></li>
           </ul>
         </div>
       </div>


### PR DESCRIPTION
I did some updates to doc generation - the Core, Flow, Runtime, Azure and Thespian docs now get generated independently so they have their own landing pages and good URLs

http://www.m-brace.net/reference/core
http://www.m-brace.net/reference/flow
http://www.m-brace.net/reference/runtime
http://www.m-brace.net/reference/azure
http://www.m-brace.net/reference/thespian

This results in less conceptual impedance/burden - you can come to MBrace without seeing anything about specific fabrics.
